### PR TITLE
Fix the fact that the api wasn't checking if an auth token is an access token 🗿 

### DIFF
--- a/src/core/auth/authorize.ts
+++ b/src/core/auth/authorize.ts
@@ -1,8 +1,14 @@
-import jwt, { JsonWebTokenError } from "jsonwebtoken";
+import jwt, { JsonWebTokenError, JwtPayload } from "jsonwebtoken";
 import { Request, Response, NextFunction } from "express";
 
 import HTTPErrors from "../errors";
 import { AccessTokenValidator, AccessToken } from "../types/validators";
+
+export function isAccessToken(
+   token_data: string | JwtPayload,
+): token_data is AccessToken {
+   return AccessTokenValidator.safeParse(token_data).success;
+}
 
 export function authorizeRequest(
    req: Request,
@@ -30,7 +36,7 @@ export function authorizeRequest(
       return;
    }
 
-   if (!AccessTokenValidator.safeParse(token_data).success) {
+   if (!isAccessToken(token_data)) {
       next(
          new HTTPErrors.InvalidTokenProvided(
             "The token you provided is not an access token, probably a refresh token",
@@ -40,6 +46,6 @@ export function authorizeRequest(
    }
 
    // i think this should be renamed to req.token
-   req.user = token_data as AccessToken;
+   req.user = token_data;
    next();
 }

--- a/src/core/types/validators.ts
+++ b/src/core/types/validators.ts
@@ -10,3 +10,25 @@ export const LoginRequest = z.object({
          "Password is required for authentication, Please provide it",
    }),
 });
+
+export const ScopesValidator = z.object({
+   socket: z.object({
+      canCreateRoom: z.boolean(),
+      canJoinRoom: z.boolean(),
+      canPlayCard: z.boolean(),
+   }),
+   self: z.object({
+      canDeleteSelf: z.boolean(),
+      canDeleteOthers: z.boolean(),
+      canCreateUSer: z.boolean(),
+   }),
+});
+
+export const AccessTokenValidator = z.object({
+   uuid: z.string().uuid(),
+   scopes: ScopesValidator,
+   iat: z.number(),
+   exp: z.number(),
+});
+
+export type AccessToken = z.infer<typeof AccessTokenValidator>;


### PR DESCRIPTION
The bug was that you could pass a refresh token to the authorize route and it wouldn't error or anything. 
This could have led to some sussy wussy undefined behaviour happening on other routes.